### PR TITLE
Use `season` from league data

### DIFF
--- a/sleeper_wrapper/league.py
+++ b/sleeper_wrapper/league.py
@@ -128,7 +128,8 @@ class League(BaseApi):
 	def get_team_score(self,starters, score_type, week):
 		total_score = 0
 		stats = Stats()
-		week_stats = stats.get_week_stats("regular", 2019, week)
+		season = self._league.get("season", 2019)
+		week_stats = stats.get_week_stats("regular", season, week)
 		for starter in starters:
 			if stats.get_player_week_stats(week_stats, starter) is not None:
 				try:


### PR DESCRIPTION
Thanks for building this api wrapper.  I was using it and couldn't get the scoreboard to work correctly.  I dug in and figured out the issue was related to a hard coded year.  I also found that the `_league` dict has a `season` value for the current season.  Seems like it would be more accurate value to use.  Hopefully this helps!